### PR TITLE
quick install command updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ line printed.
 Find your target operating system (darwin, windows, linux) and desired bin
 directory, and modify the command below as appropriate:
 
-    curl --silent --location --output=/usr/local/bin/tss https://github.com/kevinburke/tss/releases/download/0.3/tss-linux-amd64 && chmod 755 /usr/local/bin/tss
+    curl --silent --location --output /usr/local/bin/tss https://github.com/kevinburke/tss/releases/download/0.3/tss-linux-amd64 && chmod 755 /usr/local/bin/tss
 
 The latest version is 0.3.
 


### PR DESCRIPTION
Many of curl versions will break with `=`.
there are two alternative usages:

1. `curl -o /path`
2. `curl --output /path` without `=`  

```
-o, --output <file>
              Write output to <file> instead of stdout. If you are using {} or [] to fetch multiple docu-
              ments,  you can use '#' followed by a number in the <file> specifier. That variable will be
              replaced with the current string for the URL being fetched. Like in:

                curl http://{one,two}.site.com -o "file_#1.txt"

              or use several variables like:

                curl http://{site,host}.host[1-5].com -o "#1_#2"

              You may use this option as many times as the number of URLs you have.

              See also the --create-dirs option to create the local directories  dynamically.  Specifying
              the output as '-' (a single dash) will force the output to be done to stdout.
```